### PR TITLE
Turn mvsfunc into a Python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # mvsfunc
+
 mawen1250's VapourSynth functions

--- a/mvsfunc/__init__.py
+++ b/mvsfunc/__init__.py
@@ -1,0 +1,1 @@
+from .mvsfunc import *

--- a/mvsfunc/_metadata.py
+++ b/mvsfunc/_metadata.py
@@ -1,0 +1,12 @@
+"""mawen1250's VapourSynth functions"""
+
+__version__ = '10'
+
+__author__ = 'mawen1250 <mawen1250@gmail.com>'
+__maintainer__ = __author__
+
+__author_name__, __author_email__ = [x[:-1] for x in __author__.split('<')]
+__maintainer_name__, __maintainer_email__ = [x[:-1] for x in __maintainer__.split('<')]
+
+if __name__ == '__github__':
+    print(__version__)

--- a/mvsfunc/_metadata.py
+++ b/mvsfunc/_metadata.py
@@ -1,6 +1,6 @@
 """mawen1250's VapourSynth functions"""
 
-__version__ = '10'
+__version__ = '11'
 
 __author__ = 'mawen1250 <mawen1250@gmail.com>'
 __maintainer__ = __author__

--- a/mvsfunc/mvsfunc.py
+++ b/mvsfunc/mvsfunc.py
@@ -53,12 +53,12 @@
 
 
 import vapoursynth as vs
-from vapoursynth import core
 import functools
 import math
-from collections.abc import Iterable, Sequence, MutableSequence
+from collections.abc import Sequence
 from ._metadata import __version__
 
+core = vs.core
 
 ################################################################################################################################
 
@@ -253,7 +253,6 @@ def Depth(input, depth=None, sample=None, fulls=None, fulld=None,
             elif dither == "random":
                 if kwargs['ampn'] is None:
                     dither = 1
-                    ampn = 1
                 elif kwargs['ampn'] > 0:
                     dither = 1
                 else:
@@ -1010,7 +1009,7 @@ def BM3D(input, sigma=None, radius1=None, radius2=None, profile1=None, profile2=
             flt = core.std.ShufflePlanes([clip,flt,flt], [0,1,2], vs.YUV)
 
     # Final estimate
-    for i in range(0, refine):
+    for _ in range(0, refine):
         if skip:
             flt = clip
         elif radius2 < 1:
@@ -1127,11 +1126,10 @@ def VFRSplice(clips, tcfile=None, v2=None, precision=None):
         ofile = open(tcfile, 'w')
         if v2: # timecode v2
             olines = ['# timecode format v2\n']
-            frames = tc_list[len(tc_list) - 1][1] + 1
             time = 0 # ms
             for tc in tc_list:
                 frame_duration = 1000 * tc[3] / tc[2] # ms
-                for frame in range(tc[0], tc[1] + 1):
+                for _ in range(tc[0], tc[1] + 1):
                     olines.append(f'{time : <.{precision}F}\n')
                     time += frame_duration
         else: # timecode v1
@@ -1926,12 +1924,12 @@ def PointPower(clip, vpow=None, hpow=None):
     # Process
     if hpow > 0:
         clip = core.std.Transpose(clip)
-        for i in range(hpow):
+        for _ in range(hpow):
             clip = core.std.Interleave([clip, clip]).std.DoubleWeave(True).std.SelectEvery(2, 0)
         clip = core.std.Transpose(clip)
 
     if vpow > 0:
-        for i in range(vpow):
+        for _ in range(vpow):
             clip = core.std.Interleave([clip, clip]).std.DoubleWeave(True).std.SelectEvery(2, 0)
 
     # Output
@@ -2389,17 +2387,11 @@ def GetMatrix(clip, matrix=None, dIsRGB=None, id=False):
         raise type_error('"id" must be a bool!')
 
     # Resolution level
-    noneD = False
     SD = False
-    HD = False
     UHD = False
 
-    if clip.width <= 0 or clip.height <= 0:
-        noneD = True
-    elif clip.width <= 1024 and clip.height <= 576:
+    if clip.width <= 1024 and clip.height <= 576:
         SD = True
-    elif clip.width <= 2048 and clip.height <= 1536:
-        HD = True
     else:
         UHD = True
 
@@ -2742,7 +2734,7 @@ def RegisterFormat(color_family, sample_type, bits_per_sample, subsampling_w, su
 def get_func_name(num_of_call_stacks=1):
     import inspect
     frame = inspect.currentframe()
-    for stack in range(num_of_call_stacks):
+    for _ in range(num_of_call_stacks):
         frame = frame.f_back
     return frame.f_code.co_name
 ################################################################################################################################

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+VapourSynth>=45

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = Path("requirements.txt").read_text()
 
 package_name = "mvsfunc"
 
-exec(Path(f'{package_name}/_metadata.py').read_text(), meta := dict[str, str]())
+exec(Path(f'{package_name}/_metadata.py').read_text(), meta := {})
 
 setuptools.setup(
     name=package_name,

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import setuptools
+from pathlib import Path
+
+long_description = Path("README.md").read_text()
+install_requires = Path("requirements.txt").read_text()
+
+package_name = "mvsfunc"
+
+exec(Path(f'{package_name}/_metadata.py').read_text(), meta := dict[str, str]())
+
+setuptools.setup(
+    name=package_name,
+    version=meta['__version__'],
+    author=meta['__author_name__'],
+    author_email=meta['__author_email__'],
+    maintainer=meta['__maintainer_name__'],
+    maintainer_email=meta['__maintainer_email__'],
+    description=meta['__doc__'],
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    packages=[
+        package_name
+    ],
+    package_data={
+        package_name: ['py.typed'],
+    },
+    install_requires=install_requires,
+    project_urls={
+        "Source Code": 'https://github.com/HomeOfVapourSynthEvolution/mvsfunc',
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3 :: Only",
+        "Operating System :: OS Independent",
+        "Typing :: Typed",
+
+        "Topic :: Multimedia :: Video",
+    ],
+    python_requires='>=3.8',
+)

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,5 @@ setuptools.setup(
 
         "Topic :: Multimedia :: Video",
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
This makes it easier for users to install mvsfunc, and allows it to actually be used as a dependency when using strictly Python.

With this PR you can run the following command to install mvsfunc:

```
pip install git+https://github.com/HomeOfVapourSynthEvolution/mvsfunc.git
```

This also allows you to add it in a `requirements.txt` as a dependency.

Even better would be to add it to [pypi](https://pypi.org/). This will allow users to simply run `pip install mvsfunc` and it will find it in the public index. You can do that by doing [the following](https://web.archive.org/web/20220512123630/https://realpython.com/pypi-publish-python-package/#publishing-to-pypi).

I can also add in an automatic workflow file that pushes to pypi every time you update the version, but I'd like to help hands-on in that case rather than through a PR.

Furthermore, I'd like to offer to update functions to use common utility packages like `vsutil` or `vskernels`. This should make `mvsfunc` last a lot longer without needing to be constantly updated in the event of new breaking changes.