### PR TITLE
Adding newer installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # mvsfunc
 
 mawen1250's VapourSynth functions
+
+## How to install
+
+If you have the old `mvsfunc.py` module installed on your system,
+remove that from your system first. Otherwise, it might create conflicts and cause problems.
+
+Install `mvsfunc` with the following command:
+```sh
+$ pip3 install git+https://github.com/HomeOfVapourSynthEvolution/mvsfunc
+```


### PR DESCRIPTION
Since mvsfunc is now a package, that also means some newer installation instructions are needed, especially since people like me didn't notice the change, and ended up having to troubleshoot why the package wasn't working as expected :)

Some simple stuff. 
Although this approach works, this currently installs the latest leading edge git version package, so not always desirable.

It would be really appreciated if this package could be uploaded to pypi as that way, it would make publishing stable packages far easier to install to install.

Thank you @mawen1250 and have a good day.